### PR TITLE
Use colered instead of ansi_term

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,7 +520,6 @@ dependencies = [
 name = "ensight"
 version = "0.1.0"
 dependencies = [
- "ansi_term",
  "anyhow",
  "async-std",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ either = { version = "1.8.0", features = ["serde"] }
 serde_yaml = "0.9.13"
 anyhow = "1.0.65"
 base64 = "0.13.0"
-ansi_term = "0.12.1"
 time = { version = "0.3.14", features = ["serde", "serde-well-known"] }
 
 [dependencies.async-std]

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,7 +1,6 @@
 use crate::get;
 use crate::insight::{InsightItem, Insights, Item, Items};
 use crate::vcs::Vcs;
-use ansi_term::Colour;
 use colored::{Color, Colorize};
 
 pub async fn print_all(vcs: &Vcs, slug: &str, sort: bool, n: Option<usize>) -> anyhow::Result<()> {

--- a/src/text.rs
+++ b/src/text.rs
@@ -62,7 +62,6 @@ async fn print_jobs(
 fn print_insight(insight: &InsightItem) {
     let c = colorgrad::warm();
     let [r, g, b, _] = c.at(insight.metrics.success_rate).to_rgba8();
-    let style = Colour::RGB(31, 31, 31).on(Colour::RGB(r, g, b));
     let runs = format!(
         " {:3}/{:3} {:7.3}% ",
         insight.metrics.successful_runs,
@@ -75,7 +74,8 @@ fn print_insight(insight: &InsightItem) {
         insight.metrics.total_credits_used,
         insight.metrics.total_credits_used as f64 * 0.0006,
     );
-    println!("{} {}", style.paint(runs), credits);
+    let runtext = runs.truecolor(31, 31, 31).on_truecolor(r, g, b);
+    println!("{} {}", runtext, credits);
 }
 
 fn print_gr(l: usize, items: &[Item], s: &str) {

--- a/src/text.rs
+++ b/src/text.rs
@@ -87,15 +87,15 @@ fn print_gr(l: usize, items: &[Item], s: &str) {
         //    0   i  l
         //        ^ size - l + i (must be positive)
         let idx = if l < size + i { size + i - l } else { size };
-        let style = items
+        let styles = items
             .get(idx)
             .map(|item| match item.status.as_deref() {
-                Some("success") => Colour::Black.on(Colour::Green),
-                Some("failed") => Colour::Black.on(Colour::Red),
-                _ => Colour::Black.on(Colour::Yellow),
+                Some("success") => (Color::Black, Color::Green),
+                Some("failed") => (Color::Black, Color::Red),
+                _ => (Color::Black, Color::Yellow),
             })
-            .unwrap_or_else(|| Colour::Black.on(Colour::White));
+            .unwrap_or_else(|| (Color::Black, Color::White));
         let c = s.get(i..i + 1).unwrap_or(" ");
-        print!("{}", style.paint(c))
+        print!("{}", c.color(styles.0).on_color(styles.1))
     }
 }

--- a/src/text.rs
+++ b/src/text.rs
@@ -2,6 +2,7 @@ use crate::get;
 use crate::insight::{InsightItem, Insights, Item, Items};
 use crate::vcs::Vcs;
 use ansi_term::Colour;
+use colored::{Color, Colorize};
 
 pub async fn print_all(vcs: &Vcs, slug: &str, sort: bool, n: Option<usize>) -> anyhow::Result<()> {
     let path = format!("insights/{}/{}/workflows", &vcs, &slug);


### PR DESCRIPTION
- Use colored
- Replace ansi_term in print_insight
- Replace ansi_term in print_gr
- Remove ansi_term from imports
- cargo rm ansi_term
