### PR TITLE
Handle workflow fetch errors and add text helper tests

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -47,7 +47,7 @@ async fn print_jobs(
             );
             let result = get::<Items>(&token, &path)
                 .await
-                .map_err(|err| anyhow::anyhow!("failed to fetch {path}: {err:?}"))?;
+                .map_err(|err| anyhow::anyhow!("failed to fetch {path}: {err}"))?;
             print!("Job:");
             print_gr(l, &result.items, &insight.name);
             print_insight(&insight);

--- a/src/text.rs
+++ b/src/text.rs
@@ -14,7 +14,7 @@ pub async fn print_all(vcs: &Vcs, slug: &str, sort: bool, n: Option<usize>) -> a
             let path = format!("insights/{}/{}/workflows/{}", &vcs, &slug, insight.name);
             let result = get::<Items>(&token, &path)
                 .await
-                .map_err(|err| anyhow::anyhow!("failed to fetch {path}: {err:?}"))?;
+                .map_err(|err| anyhow::anyhow!("failed to fetch {path}: {err}"))?;
             println!();
             print!("Workflow:");
             print_gr(l, &result.items, &insight.name);

--- a/src/text.rs
+++ b/src/text.rs
@@ -106,3 +106,61 @@ fn print_gr(l: usize, items: &[Item], s: &str) {
         print!("{}", c.color(styles.0).on_color(styles.1))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::insight::{DurationMetrics, Metrics};
+    use time::OffsetDateTime;
+
+    fn insight(name: &str, success_rate: f64) -> InsightItem {
+        InsightItem {
+            name: name.to_string(),
+            metrics: Metrics {
+                success_rate,
+                total_runs: 0,
+                failed_runs: 0,
+                successful_runs: 0,
+                throughput: 0.0,
+                duration_metrics: DurationMetrics {
+                    min: 0,
+                    max: 0,
+                    median: 0,
+                    mean: 0,
+                    p95: 0,
+                    standard_deviation: 0.0,
+                },
+                total_credits_used: 0,
+            },
+            window_start: OffsetDateTime::UNIX_EPOCH,
+            window_end: OffsetDateTime::UNIX_EPOCH,
+        }
+    }
+
+    #[test]
+    fn insight_name_width_is_zero_for_empty_items() {
+        assert_eq!(insight_name_width(&[]), 0);
+    }
+
+    #[test]
+    fn insight_name_width_uses_longest_name() {
+        let items = vec![insight("build", 1.0), insight("integration", 1.0)];
+
+        assert_eq!(insight_name_width(&items), "integration".len());
+    }
+
+    #[test]
+    fn sort_by_success_rate_handles_nan_without_panic() {
+        let mut items = vec![
+            insight("ok", 1.0),
+            insight("nan", f64::NAN),
+            insight("failed", 0.0),
+        ];
+
+        sort_by_success_rate(&mut items);
+
+        assert_eq!(items[0].name, "failed");
+        assert_eq!(items[1].name, "ok");
+        assert_eq!(items[2].name, "nan");
+    }
+}

--- a/src/text.rs
+++ b/src/text.rs
@@ -9,10 +9,12 @@ pub async fn print_all(vcs: &Vcs, slug: &str, sort: bool, n: Option<usize>) -> a
     let token = std::env::var("CIRCLECI_TOKEN")?;
     let result = get::<Insights>(&token, &path).await;
     if let Ok(insights) = result {
-        let l = n.unwrap_or_else(|| insights.items.iter().map(|i| i.name.len()).max().unwrap());
+        let l = n.unwrap_or_else(|| insight_name_width(&insights.items));
         for insight in &insights.items {
             let path = format!("insights/{}/{}/workflows/{}", &vcs, &slug, insight.name);
-            let result = get::<Items>(&token, &path).await.unwrap();
+            let result = get::<Items>(&token, &path)
+                .await
+                .map_err(|err| anyhow::anyhow!("failed to fetch {path}: {err:?}"))?;
             println!();
             print!("Workflow:");
             print_gr(l, &result.items, &insight.name);
@@ -35,20 +37,17 @@ async fn print_jobs(
     let result = get::<Insights>(&token, &path).await;
     if let Ok(mut insights) = result {
         if sort {
-            insights.items.sort_by(|a, b| {
-                a.metrics
-                    .success_rate
-                    .partial_cmp(&b.metrics.success_rate)
-                    .unwrap()
-            });
+            sort_by_success_rate(&mut insights.items);
         }
-        let l = n.unwrap_or_else(|| insights.items.iter().map(|i| i.name.len()).max().unwrap());
+        let l = n.unwrap_or_else(|| insight_name_width(&insights.items));
         for insight in insights.items {
             let path = format!(
                 "insights/{}/{}/workflows/{}/jobs/{}",
                 &vcs, &slug, workflow, insight.name
             );
-            let result = get::<Items>(&token, &path).await.unwrap();
+            let result = get::<Items>(&token, &path)
+                .await
+                .map_err(|err| anyhow::anyhow!("failed to fetch {path}: {err:?}"))?;
             print!("Job:");
             print_gr(l, &result.items, &insight.name);
             print_insight(&insight);
@@ -57,6 +56,14 @@ async fn print_jobs(
         println!("{result:#?}");
     }
     Ok(())
+}
+
+fn insight_name_width(items: &[InsightItem]) -> usize {
+    items.iter().map(|item| item.name.len()).max().unwrap_or(0)
+}
+
+fn sort_by_success_rate(items: &mut [InsightItem]) {
+    items.sort_by(|a, b| a.metrics.success_rate.total_cmp(&b.metrics.success_rate));
 }
 
 fn print_insight(insight: &InsightItem) {


### PR DESCRIPTION
## Summary
- Replace `unwrap()` on workflow/job fetches with contextual errors
- Extract helpers for insight name width and success-rate sorting
- Add tests for empty widths, longest-name handling, and NaN-safe sorting

## Testing
- Added unit tests covering the new helper behavior
- Not run (not requested)